### PR TITLE
Add get_personroles function

### DIFF
--- a/lib/rbac.ex
+++ b/lib/rbac.ex
@@ -74,6 +74,24 @@ defmodule RBAC do
   end
 
   @doc """
+  `get_personroles` fetches a list of roles assigned to a person from the
+  specified `auth_url`, based off the `person_id`
+  """
+  def get_personroles(auth_url, person_id) do
+    get_personroles(auth_url, person_id, AuthPlug.Token.client_id())
+  end
+
+  def get_personroles(auth_url, person_id, client_id) do
+    case HTTPoison.get("#{auth_url}/personroles/#{person_id}/#{client_id}") do
+      {:ok, resp} ->
+        Map.get(resp, :body) |> Jason.decode()
+      {:error, _} = err ->
+        err
+    end
+
+  end
+
+  @doc """
   `init_roles/2` fetches the list of roles for an app
   from the auth app (auth_url) based on the client_id
   and caches the list in-memory (ETS) for fast access.

--- a/test/rbac_test.exs
+++ b/test/rbac_test.exs
@@ -247,4 +247,8 @@ defmodule RBACTest do
     {:ok, roles} = RBAC.get_personroles("https://dwylauth.herokuapp.com", 9089056)
     assert is_list(roles)
   end
+
+  test "RBAC.get_personroles errors when given wrong data" do
+    assert {:error, _} = RBAC.get_approles("https://doesnotexist", 1)
+  end
 end

--- a/test/rbac_test.exs
+++ b/test/rbac_test.exs
@@ -241,4 +241,10 @@ defmodule RBACTest do
     init()
     assert length(RBAC.list_approles()) > 7
   end
+
+  test "RBAC.get_personroles returns the correct data" do
+    # Cheaty test until blocking PR complete
+    {:ok, roles} = RBAC.get_personroles("https://dwylauth.herokuapp.com", 9089056)
+    assert is_list(roles)
+  end
 end


### PR DESCRIPTION
As discussed in dwyl/auth#121 this adds a function that fetches a list of person_roles from
a remote endpoint.

The added test is a small bodge until we can properly assign people to roles in auth﻿
